### PR TITLE
Changes to make it compile on ubuntu 14.04 gcc 6.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 # Makefile to build shared library of libsvc
 #
 
+PROGNAME	?=example
+
 MAJOR_VERSION := 0
 MINOR_VERSION := 1
 PATCH_VERSION := 0

--- a/htsmsg.c
+++ b/htsmsg.c
@@ -669,13 +669,15 @@ htsmsg_print0(htsmsg_t *msg, int indent)
     case HMF_MAP:
       printf("MAP) = {\n");
       htsmsg_print0(&f->hmf_msg, indent + 1);
-      for(i = 0; i < indent; i++) printf("\t"); printf("}\n");
+      for(i = 0; i < indent; i++) printf("\t");
+      printf("}\n");
       break;
 
     case HMF_LIST:
       printf("LIST) = {\n");
       htsmsg_print0(&f->hmf_msg, indent + 1);
-      for(i = 0; i < indent; i++) printf("\t"); printf("}\n");
+      for(i = 0; i < indent; i++) printf("\t");
+      printf("}\n");
       break;
       
     case HMF_STR:

--- a/misc.c
+++ b/misc.c
@@ -398,7 +398,7 @@ get_random_bytes(void *out, size_t len)
   static int fd = -1;
 
   int r;
-#ifdef __linux__
+#if defined(__linux__) && defined(SYS_getrandom)
   while(len > 0) {
     r = syscall(SYS_getrandom, out, len, 0);
     if(r == -1) {

--- a/sources.mk
+++ b/sources.mk
@@ -68,6 +68,8 @@ ifeq (${WITH_CURL},yes)
 
 CFLAGS  += -DWITH_CURL
 
+CFLAGS  += -DPROGNAME='"${PROGNAME}"'
+
 ifeq ($(shell uname),Darwin)
 LDFLAGS += -lcurl -lz -liconv
 endif
@@ -102,9 +104,10 @@ endif
 ##############################################################
 
 ifeq (${WITH_WS_CLIENT},yes)
-libsvc_SRCS    +=  websocket_client.c websocket.c
+libsvc_SRCS    +=  websocket_client.c
 libsvc_INCS    +=  websocket_client.h
 CFLAGS += -DWITH_WS_CLIENT
+WITH_WS_SOURCE=yes
 endif
 
 ##############################################################
@@ -112,10 +115,15 @@ endif
 ##############################################################
 
 ifeq (${WITH_HTTP_SERVER},yes)
-libsvc_SRCS    += http.c http_parser.c websocket.c
+libsvc_SRCS    += http.c http_parser.c
 libsvc_INCS    += http.h http_parser.h websocket.h
 WITH_ASYNCIO   := yes
 CFLAGS += -DWITH_HTTP_SERVER
+WITH_WS_SOURCE=yes
+endif
+
+ifeq (${WITH_WS_SOURCE},yes)
+libsvc_SRCS    +=  websocket.c
 endif
 
 ##############################################################

--- a/utf8.c
+++ b/utf8.c
@@ -159,11 +159,11 @@ utf8_get(const char **s, const char *stop)
     while(l-- > 0) {
       if(*s == stop)
         return 0xfffd;
-        c = **s;
-        if((c & 0xc0) != 0x80)
+      c = **s;
+      if((c & 0xc0) != 0x80)
             return 0xfffd;
-        *s = *s + 1;
-        r = r << 6 | (c & 0x3f);
+      *s = *s + 1;
+      r = r << 6 | (c & 0x3f);
     }
     if(r < m)
         return 0xfffd; // overlong sequence


### PR DESCRIPTION
There was double inclusion of websockets.c when WITH_WS_CLIENT and WITH_WS_SERVER are defined.
GCC 6.2 complains and flag as error misleading code indentation.
Add a default PROGNAME value and add it to CCFLAGS