### PR TITLE
asyncio: remove conflicting MSG_NOSIGNAL definition

### DIFF
--- a/asyncio.c
+++ b/asyncio.c
@@ -412,7 +412,6 @@ mod_poll_flags(asyncio_fd_t *af, int set, int clr)
 
 #define EPOLLIN  0x1
 #define EPOLLOUT 0x2
-#define MSG_NOSIGNAL 0
 #define MSG_MORE 0
 
 /**


### PR DESCRIPTION
On latest macOS I get:

```
/Users/martin/dev/lk/transcribe/libsvc/asyncio.c:415:9: error: 'MSG_NOSIGNAL' macro redefined [-Werror,-Wmacro-redefined]
#define MSG_NOSIGNAL 0
        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/socket.h:584:9: note: previous definition is here
#define MSG_NOSIGNAL    0x80000         /* do not generate SIGPIPE on EOF */
        ^
```